### PR TITLE
Add upper bound to Kaspi order creation filters

### DIFF
--- a/bin/fetch_new.php
+++ b/bin/fetch_new.php
@@ -68,6 +68,7 @@ $creationDateFrom = max($watermark, $minAllowed);
 $filters = [
     // Kaspi limits filtering by creationDate to the last 14 days
     'filter[orders][creationDate][$ge]' => $creationDateFrom,
+    'filter[orders][creationDate][$le]' => $nowMs,
     'filter[orders][state]' => 'NEW', // adjust as needed
 ];
 

--- a/bin/reconcile.php
+++ b/bin/reconcile.php
@@ -20,6 +20,7 @@ $from = max($sevenDaysAgo, $lastCheck);
 
 $filters = [
     'filter[orders][creationDate][$ge]' => $from,
+    'filter[orders][creationDate][$le]' => $nowMs,
 ];
 
 $updated = 0;


### PR DESCRIPTION
## Summary
- add a creation date upper-bound when fetching new Kaspi orders to avoid exceeding the 14-day window
- ensure reconciliation queries also cap creation dates at the current time to comply with Kaspi limits

## Testing
- php bin/fetch_new.php *(fails: missing/invalid environment configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d82d3de7cc83308f4abb738e6445c1