### PR TITLE
Include product name in Kaspi order summary notes

### DIFF
--- a/bin/fetch_new.php
+++ b/bin/fetch_new.php
@@ -199,7 +199,7 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
             $title = (string) ($eAttrs['productName'] ?? ($eAttrs['name'] ?? 'Товар'));
             $sku = (string) ($eAttrs['productCode'] ?? ($eAttrs['code'] ?? $title));
             $priceItem = (int) ($eAttrs['basePrice'] ?? ($eAttrs['totalPrice'] ?? 0));
-            $lines[] = [$sku, $qty, $priceItem];
+            $lines[] = [$title, $sku, $qty, $priceItem];
 
             // find or create catalog element by SKU or title
             $found = $amo->findCatalogElement($catalogId, $sku ?: $title);
@@ -215,8 +215,8 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
         }
         // summary note
         if ($lines) {
-            $text = "Позиции заказа:\nSKU | Qty | Price\n";
-            foreach ($lines as [$s,$q,$p]) { $text .= "{$s} | {$q} | {$p}\n"; }
+            $text = "Позиции заказа:\nName | SKU | Qty | Price\n";
+            foreach ($lines as [$n,$s,$q,$p]) { $text .= "{$n} | {$s} | {$q} | {$p}\n"; }
             $amo->addNote($leadId, $text);
         }
     }


### PR DESCRIPTION
## Summary
- append product names to the stored line items so note generation has access to both SKU and title
- update the order note header and rows to include the product name column

## Testing
- php -l bin/fetch_new.php

------
https://chatgpt.com/codex/tasks/task_e_68d8492d198c83309a0a7ef986fd49c3