### PR TITLE
Add total price handling for orders reconciliation

### DIFF
--- a/bin/fetch_new.php
+++ b/bin/fetch_new.php
@@ -186,8 +186,14 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
     }
 
     // store map
-    $stmt = $pdo->prepare("INSERT INTO orders_map(order_code, kaspi_order_id, lead_id, created_at) VALUES(:c,:o,:l, NOW())");
-    $stmt->execute([':c'=>$code, ':o'=>$orderId, ':l'=>$leadId]);
+    if ($row) {
+        $stmt = $pdo->prepare("UPDATE orders_map SET kaspi_order_id=:o, lead_id=:l, total_price=:p WHERE order_code=:c");
+    } else {
+        $stmt = $pdo->prepare(
+            "INSERT INTO orders_map(order_code, kaspi_order_id, lead_id, total_price, created_at) VALUES(:c,:o,:l,:p, NOW())"
+        );
+    }
+    $stmt->execute([':c'=>$code, ':o'=>$orderId, ':l'=>$leadId, ':p'=>$price]);
 
     // add items
     if ($catalogId > 0) {

--- a/migrations/mysql.sql
+++ b/migrations/mysql.sql
@@ -7,8 +7,12 @@ CREATE TABLE IF NOT EXISTS orders_map (
   order_code VARCHAR(64) PRIMARY KEY,
   kaspi_order_id VARCHAR(64) NOT NULL,
   lead_id BIGINT NOT NULL,
+  total_price BIGINT,
   created_at DATETIME NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+ALTER TABLE orders_map
+  ADD COLUMN IF NOT EXISTS total_price BIGINT;
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   service VARCHAR(32) PRIMARY KEY,

--- a/migrations/pgsql.sql
+++ b/migrations/pgsql.sql
@@ -7,8 +7,12 @@ CREATE TABLE IF NOT EXISTS orders_map (
   order_code TEXT PRIMARY KEY,
   kaspi_order_id TEXT NOT NULL,
   lead_id BIGINT NOT NULL,
+  total_price NUMERIC(20,0),
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE IF EXISTS orders_map
+  ADD COLUMN IF NOT EXISTS total_price NUMERIC(20,0);
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   service TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add a total_price column to the orders_map table for both MySQL and PostgreSQL and provide ALTER statements for existing databases
- persist Kaspi totalPrice values when inserting or updating order-to-lead mappings
- reuse the stored total_price during reconciliation to avoid unnecessary lead updates while keeping the mapping in sync

## Testing
- php -l bin/fetch_new.php
- php -l bin/reconcile.php

------
https://chatgpt.com/codex/tasks/task_e_68d8492a2e10833082e3779ecfe7401c