### PR TITLE
Remove default Kaspi tag from new contacts

### DIFF
--- a/bin/fetch_new.php
+++ b/bin/fetch_new.php
@@ -126,7 +126,7 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
             (string)$last,
             $respUserId ?: null,
             $contactCustomFields,
-            [['name' => 'Kaspi']]
+            []
         )];
         $contactRes = $amo->createContacts($contactPayload);
         $createdContact = $contactRes['_embedded']['contacts'][0] ?? null;

--- a/tests/PayloadTagsTest.php
+++ b/tests/PayloadTagsTest.php
@@ -10,8 +10,8 @@ function assertTrue(bool $condition, string $message): void {
     }
 }
 
-$contact = amoBuildContactPayload('Kaspi', 'Customer', null, [], [['name' => 'Kaspi']]);
-assertTrue(isset($contact['_embedded']['tags']), 'У контакта отсутствуют теги в _embedded');
+$contact = amoBuildContactPayload('Kaspi', 'Customer', null, [], []);
+assertTrue(!isset($contact['_embedded']['tags']), 'У контакта не должно быть тегов в _embedded, если массив тегов пуст');
 assertTrue(!isset($contact['tags']), 'Корневой ключ tags не должен присутствовать у контакта');
 assertTrue(!array_key_exists('custom_fields_values', $contact), 'custom_fields_values не должен присутствовать, если массив пуст');
 
@@ -24,6 +24,7 @@ $customField = [
 ];
 $contactWithFields = amoBuildContactPayload('Kaspi', 'Customer', 42, [$customField], [['name' => 'Kaspi']]);
 assertTrue(array_key_exists('custom_fields_values', $contactWithFields), 'custom_fields_values должен присутствовать, если массив не пуст');
+assertTrue(isset($contactWithFields['_embedded']['tags']), 'У контакта должны быть теги в _embedded, если они переданы');
 
 $lead = amoBuildLeadPayload(
     'Kaspi Order 123',


### PR DESCRIPTION
## Summary
- stop passing the Kaspi tag when building contacts for new orders
- update payload tests to ensure contacts remain untagged when no tags are provided

## Testing
- php tests/PayloadTagsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d84d5b4fa88330a6e00b046c9f65bb