### PR TITLE
Wrap Kaspi lead creation in a transaction

### DIFF
--- a/lib/AmoClient.php
+++ b/lib/AmoClient.php
@@ -185,6 +185,10 @@ final class AmoClient {
         return $this->request('PATCH', '/api/v4/leads', [$fields]);
     }
 
+    public function deleteLead(int $id): void {
+        $this->request('DELETE', "/api/v4/leads/{$id}");
+    }
+
     public function linkLeadToCatalogElement(int $leadId, int $catalogId, int $elementId, int $qty): void {
         $payload = [ [ 'to_entity_id' => $elementId, 'to_entity_type' => 'catalog_elements',
                        'metadata' => ['quantity' => $qty, 'catalog_id' => $catalogId] ] ];


### PR DESCRIPTION
## Summary
- wrap lead creation, orders_map writes, and amoCRM enrichment in a PDO transaction with rollback handling
- clean up orphaned leads on failure and log errors before moving to the next order
- expose AmoClient::deleteLead() and only update the Kaspi watermark after a successful commit

## Testing
- php -l bin/fetch_new.php
- php -l lib/AmoClient.php


------
https://chatgpt.com/codex/tasks/task_e_68d8f762417883309e61b377bb5e5ccb