### PR TITLE
Paginate Kaspi order entries retrieval

### DIFF
--- a/bin/reconcile.php
+++ b/bin/reconcile.php
@@ -59,8 +59,9 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
 
     // Refresh entries (re-link quantities)
     if ($catalogId > 0) {
-        $entries = $kaspi->getOrderEntries($orderId);
-        foreach ($entries as $e) {
+        $hasEntries = false;
+        foreach ($kaspi->getOrderEntries($orderId) as $e) {
+            $hasEntries = true;
             $eAttrs = $e['attributes'] ?? [];
             $qty = (int) ($eAttrs['quantity'] ?? 1);
             $title = (string) ($eAttrs['productName'] ?? ($eAttrs['name'] ?? 'Товар'));
@@ -77,6 +78,9 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
             if ($found && isset($found['id'])) {
                 $amo->linkLeadToCatalogElement($leadId, $catalogId, (int)$found['id'], max(1,$qty));
             }
+        }
+        if (!$hasEntries) {
+            Logger::info('Order has no entries during reconcile', ['order_id' => $orderId, 'code' => $code]);
         }
     }
 

--- a/lib/KaspiClient.php
+++ b/lib/KaspiClient.php
@@ -68,8 +68,25 @@ final class KaspiClient {
         }
     }
 
-    public function getOrderEntries(string $orderId): array {
-        $data = $this->request('GET', "/orders/{$orderId}/entries");
-        return $data['data'] ?? [];
+    public function getOrderEntries(string $orderId, int $pageSize = 100): iterable {
+        $page = 0;
+        while (true) {
+            $query = [
+                'page[number]' => $page,
+                'page[size]' => $pageSize,
+            ];
+            $data = $this->request('GET', "/orders/{$orderId}/entries", $query);
+            $items = $data['data'] ?? [];
+            if (!$items) {
+                break;
+            }
+            foreach ($items as $item) {
+                yield $item;
+            }
+            $page++;
+            if (count($items) < $pageSize) {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- paginate Kaspi order entry retrieval so all pages are processed
- update fetch_new and reconcile scripts to work with the iterable entries and log empty orders
- keep order notes and catalog links intact when entries are available

## Testing
- php -l lib/KaspiClient.php
- php -l bin/fetch_new.php
- php -l bin/reconcile.php

------
https://chatgpt.com/codex/tasks/task_e_68d9022e013c8330aead65f1820bc240