### PR TITLE
Implement transactional reservation for order fetch

### DIFF
--- a/migrations/mysql.sql
+++ b/migrations/mysql.sql
@@ -8,11 +8,17 @@ CREATE TABLE IF NOT EXISTS orders_map (
   kaspi_order_id VARCHAR(64) NOT NULL,
   lead_id BIGINT NOT NULL,
   total_price BIGINT,
+  processing_token VARCHAR(64),
+  processing_at DATETIME NULL,
   created_at DATETIME NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 ALTER TABLE orders_map
   ADD COLUMN IF NOT EXISTS total_price BIGINT;
+ALTER TABLE orders_map
+  ADD COLUMN IF NOT EXISTS processing_token VARCHAR(64);
+ALTER TABLE orders_map
+  ADD COLUMN IF NOT EXISTS processing_at DATETIME NULL;
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   service VARCHAR(32) PRIMARY KEY,

--- a/migrations/pgsql.sql
+++ b/migrations/pgsql.sql
@@ -8,11 +8,17 @@ CREATE TABLE IF NOT EXISTS orders_map (
   kaspi_order_id TEXT NOT NULL,
   lead_id BIGINT NOT NULL,
   total_price NUMERIC(20,0),
+  processing_token TEXT,
+  processing_at TIMESTAMP NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
 ALTER TABLE IF EXISTS orders_map
   ADD COLUMN IF NOT EXISTS total_price NUMERIC(20,0);
+ALTER TABLE IF EXISTS orders_map
+  ADD COLUMN IF NOT EXISTS processing_token TEXT;
+ALTER TABLE IF EXISTS orders_map
+  ADD COLUMN IF NOT EXISTS processing_at TIMESTAMP NULL;
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
   service TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add explicit transactional reservation with processing flags in bin/fetch_new.php to avoid duplicate lead creation
- extend MySQL and PostgreSQL migrations with processing_token and processing_at columns for orders_map entries

## Testing
- php -l bin/fetch_new.php

------
https://chatgpt.com/codex/tasks/task_e_68d905c8e1cc8330b12a37d66ad7928a