### PR TITLE
Add status mapping migrations and extend orders_map schema

### DIFF
--- a/migrations/add_orders_map_columns.sql
+++ b/migrations/add_orders_map_columns.sql
@@ -6,6 +6,22 @@ SET @col_exists := (
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = DATABASE()
     AND TABLE_NAME = 'orders_map'
+    AND COLUMN_NAME = 'kaspi_status'
+);
+SET @ddl := IF(
+  @col_exists = 0,
+  'ALTER TABLE `orders_map` ADD COLUMN `kaspi_status` VARCHAR(64) NULL DEFAULT NULL;',
+  'SELECT 0;'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @col_exists := (
+  SELECT COUNT(*)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'orders_map'
     AND COLUMN_NAME = 'total_price'
 );
 SET @ddl := IF(

--- a/migrations/mysql.sql
+++ b/migrations/mysql.sql
@@ -6,12 +6,29 @@ CREATE TABLE IF NOT EXISTS settings (
 CREATE TABLE IF NOT EXISTS orders_map (
   order_code VARCHAR(64) PRIMARY KEY,
   kaspi_order_id VARCHAR(64) NOT NULL,
+  kaspi_status VARCHAR(64) DEFAULT NULL,
   lead_id BIGINT NOT NULL,
   total_price BIGINT,
   processing_token VARCHAR(64),
   processing_at DATETIME NULL,
   created_at DATETIME NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+SET @col_exists := (
+  SELECT COUNT(*)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'orders_map'
+    AND COLUMN_NAME = 'kaspi_status'
+);
+SET @ddl := IF(
+  @col_exists = 0,
+  'ALTER TABLE `orders_map` ADD COLUMN `kaspi_status` VARCHAR(64) NULL DEFAULT NULL;',
+  'SELECT 0;'
+);
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 SET @col_exists := (
   SELECT COUNT(*)

--- a/migrations/pgsql.sql
+++ b/migrations/pgsql.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS settings (
 CREATE TABLE IF NOT EXISTS orders_map (
   order_code TEXT PRIMARY KEY,
   kaspi_order_id TEXT NOT NULL,
+  kaspi_status TEXT,
   lead_id BIGINT NOT NULL,
   total_price NUMERIC(20,0),
   processing_token TEXT,
@@ -13,6 +14,8 @@ CREATE TABLE IF NOT EXISTS orders_map (
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+ALTER TABLE IF EXISTS orders_map
+  ADD COLUMN IF NOT EXISTS kaspi_status TEXT;
 ALTER TABLE IF EXISTS orders_map
   ADD COLUMN IF NOT EXISTS total_price NUMERIC(20,0);
 ALTER TABLE IF EXISTS orders_map

--- a/migrations/status_mapping_mysql.sql
+++ b/migrations/status_mapping_mysql.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS status_mapping (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  kaspi_status VARCHAR(64) NOT NULL,
+  amo_pipeline_id BIGINT NOT NULL,
+  amo_status_id BIGINT NOT NULL,
+  amo_responsible_user_id BIGINT DEFAULT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY status_mapping_kaspi_status_unique (kaspi_status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/migrations/status_mapping_pgsql.sql
+++ b/migrations/status_mapping_pgsql.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS status_mapping (
+  id BIGSERIAL PRIMARY KEY,
+  kaspi_status TEXT NOT NULL,
+  amo_pipeline_id BIGINT NOT NULL,
+  amo_status_id BIGINT NOT NULL,
+  amo_responsible_user_id BIGINT,
+  created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS status_mapping_kaspi_status_unique
+  ON status_mapping (kaspi_status);
+
+CREATE OR REPLACE FUNCTION set_status_mapping_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = 'status_mapping_set_updated_at'
+  ) THEN
+    CREATE TRIGGER status_mapping_set_updated_at
+    BEFORE UPDATE ON status_mapping
+    FOR EACH ROW
+    EXECUTE PROCEDURE set_status_mapping_updated_at();
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add dedicated MySQL and PostgreSQL migration scripts for the new status_mapping table with automatic timestamp handling
- extend orders_map migrations to include the kaspi_status column for both database engines
- update the legacy MySQL helper script so existing installs can add the new kaspi_status column when needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daef0cf8788330af259c772e8da079