### PR TITLE
Add is_active column and composite index to status mapping migrations

### DIFF
--- a/migrations/status_mapping_mysql.sql
+++ b/migrations/status_mapping_mysql.sql
@@ -4,8 +4,57 @@ CREATE TABLE IF NOT EXISTS status_mapping (
   amo_pipeline_id BIGINT NOT NULL,
   amo_status_id BIGINT NOT NULL,
   amo_responsible_user_id BIGINT DEFAULT NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
-  UNIQUE KEY status_mapping_kaspi_status_unique (kaspi_status)
+  UNIQUE KEY status_mapping_kaspi_status_pipeline_unique (kaspi_status, amo_pipeline_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+SET @column_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name = 'status_mapping'
+    AND column_name = 'is_active'
+);
+SET @add_column_sql = IF(
+  @column_exists = 0,
+  'ALTER TABLE status_mapping ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER amo_responsible_user_id',
+  'SELECT 1'
+);
+PREPARE stmt FROM @add_column_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @old_index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'status_mapping'
+    AND index_name = 'status_mapping_kaspi_status_unique'
+);
+SET @drop_index_sql = IF(
+  @old_index_exists > 0,
+  'ALTER TABLE status_mapping DROP INDEX status_mapping_kaspi_status_unique',
+  'SELECT 1'
+);
+PREPARE stmt FROM @drop_index_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @new_index_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'status_mapping'
+    AND index_name = 'status_mapping_kaspi_status_pipeline_unique'
+);
+SET @add_index_sql = IF(
+  @new_index_exists = 0,
+  'ALTER TABLE status_mapping ADD UNIQUE INDEX status_mapping_kaspi_status_pipeline_unique (kaspi_status, amo_pipeline_id)',
+  'SELECT 1'
+);
+PREPARE stmt FROM @add_index_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## Summary
- add the is_active column to new MySQL and PostgreSQL status mapping tables and include it in export selections
- update migrations to add the column and replace the unique index with a kaspi_status and amo_pipeline_id pair for existing installations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafa0c507883309b659988db407360