### PR TITLE
Introduce single status mapping resolution methods

### DIFF
--- a/bin/fetch_new.php
+++ b/bin/fetch_new.php
@@ -143,15 +143,12 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
     if ($kaspiOrderStatus === '') {
         $kaspiOrderStatus = 'NEW';
     }
-    $defaultStatusId = $statusId ?: null;
+    $defaultStatusId = $statusId > 0 ? $statusId : null;
     $effectiveStatusId = $defaultStatusId;
     if ($kaspiOrderStatus !== '') {
-        $mappedStatusIds = $statusMappingManager->getAmoStatusIds($kaspiOrderStatus, $pipelineId, true);
-        foreach ($mappedStatusIds as $candidateStatusId) {
-            if ($candidateStatusId > 0) {
-                $effectiveStatusId = $candidateStatusId;
-                break;
-            }
+        $mappedStatusId = $statusMappingManager->getAmoStatusId($kaspiOrderStatus, $pipelineId);
+        if ($mappedStatusId !== null && $mappedStatusId > 0) {
+            $effectiveStatusId = $mappedStatusId;
         }
     }
     $processingToken = bin2hex(random_bytes(16));

--- a/bin/reconcile.php
+++ b/bin/reconcile.php
@@ -13,6 +13,7 @@ $productCache = [];
 
 $catalogId  = (int) env('AMO_CATALOG_ID', '0');
 $pipelineId = (int) env('AMO_PIPELINE_ID', '0');
+$defaultStatusId = (int) env('AMO_STATUS_ID', '0');
 
 $lastCheck = (int) (Db::getSetting('last_check_ms', '0') ?? '0');
 $nowMs = (int) (microtime(true) * 1000);
@@ -46,13 +47,9 @@ foreach ($kaspi->listOrders($filters, 100) as $order) {
     $storedKaspiStatus = isset($row['kaspi_status']) ? trim((string)$row['kaspi_status']) : '';
 
     if ($kaspiState !== '' && $kaspiState !== $storedKaspiStatus) {
-        $mappedStatusIds = $statusMappingManager->getAmoStatusIds($kaspiState, $pipelineId, true);
-        $nextStatusId = null;
-        foreach ($mappedStatusIds as $candidateStatusId) {
-            if ($candidateStatusId > 0) {
-                $nextStatusId = $candidateStatusId;
-                break;
-            }
+        $nextStatusId = $statusMappingManager->getAmoStatusId($kaspiState, $pipelineId);
+        if (($nextStatusId === null || $nextStatusId <= 0) && $defaultStatusId > 0) {
+            $nextStatusId = $defaultStatusId;
         }
         if ($nextStatusId !== null) {
             try {


### PR DESCRIPTION
## Summary
- add single-record helpers in `StatusMappingManager` and adjust the upsert signature to remove the unused sort order argument while still returning the affected ID
- update the public API endpoints to work with the new helpers and require a single amo status identifier
- refactor cron scripts to resolve amo statuses via the single-record helper with a fallback to the configured default status

## Testing
- php -l lib/StatusMappingManager.php
- php -l public/api_status_mapping.php
- php -l bin/fetch_new.php
- php -l bin/reconcile.php

------
https://chatgpt.com/codex/tasks/task_e_68de228b7c848330b893c1478c3a4d6c